### PR TITLE
Make key name be compatible with resque

### DIFF
--- a/resque.go
+++ b/resque.go
@@ -47,5 +47,5 @@ func (enqueuer *redisEnqueuer) Enqueue(queue, jobClass string, args ...jobArg) (
 		return -1, err
 	}
 
-	return enqueuer.drv.ListPush(queue, string(jobJson))
+	return enqueuer.drv.ListPush("resque:queue:"+queue, string(jobJson))
 }


### PR DESCRIPTION
With this fix, the sample code on README worked with resque. 

FYI: [goworker](https://github.com/benmanns/goworker) also worked with go-resque with goworker codes such as

``` go
package main

import (
        "fmt"
        "github.com/benmanns/goworker"
)

func myFunc(queue string, args ...interface{}) error {
        fmt.Printf("From %s, %v\n", queue, args)
        return nil
}

func init() {
        goworker.Register("Demo::Job", myFunc)
}

func main() {
        if err := goworker.Work(); err != nil {
                fmt.Println("Error:", err)
        }
}
```

```
$ go run worker.go -queues=default
```
