### PR TITLE
Add the queue to resque if it doesn't exist when adding a job

### DIFF
--- a/go-redis/driver.go
+++ b/go-redis/driver.go
@@ -28,6 +28,9 @@ func (d *drv) SetClient(name string, client interface{}) {
 }
 
 func (d *drv) ListPush(queue string, jobJSON string) (int64, error) {
+	// Ensure the queue exists
+	_, err := d.client.SAdd(d.nameSpace+"queues", queue)
+
 	listLength, err := d.client.RPush(d.nameSpace+"queue:"+queue, jobJSON)
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
Similar to what ActiveJob does in RoRails, when adding a job, if the queue doesn't exist, it would be handy if it was created at that time.

That way, after performing a redis flushall or spinning up a new instance, you don't need to recreate those by hand

Only done the go-redis driver as its the one I use, I expect applying the same principle to other drivers shouldn't be too hard but I don't have enough time to test them all so I limited it to the go-redis one