### PR TITLE
Move sleeps in polls into the for loop.

### DIFF
--- a/godis/driver.go
+++ b/godis/driver.go
@@ -61,7 +61,7 @@ func (d *drv) Poll() {
 					d.client.Lpush(d.nameSpace+"queue:"+queue, jobs[0])
 				}
 			}
+			time.Sleep(100 * time.Millisecond)
 		}
-		time.Sleep(100 * time.Millisecond)
 	}(d)
 }

--- a/hoisie/driver.go
+++ b/hoisie/driver.go
@@ -70,7 +70,7 @@ func (d *drv) Poll() {
 					d.client.Lpush(d.nameSpace+"queue:"+queue, []byte(jobs[0]))
 				}
 			}
+			time.Sleep(100 * time.Millisecond)
 		}
-		time.Sleep(100 * time.Millisecond)
 	}(d)
 }

--- a/redigo/driver.go
+++ b/redigo/driver.go
@@ -64,7 +64,7 @@ func (d *drv) Poll() {
 					(*d.client).Do("LPUSH", d.nameSpace+"queue:"+queue, jobs[0])
 				}
 			}
+			time.Sleep(100 * time.Millisecond)
 		}
-		time.Sleep(100 * time.Millisecond)
 	}(d)
 }

--- a/redisv2/driver.go
+++ b/redisv2/driver.go
@@ -62,7 +62,7 @@ func (d *drv) Poll() {
 					d.client.Lpush(d.nameSpace+"queue:"+queue, []byte(jobs[0]))
 				}
 			}
+			time.Sleep(100 * time.Millisecond)
 		}
-		time.Sleep(100 * time.Millisecond)
 	}(d)
 }


### PR DESCRIPTION
Sleeps were added to polls, but most were added outside of the loop. Moving them inside the loop should stop the crazy cpu usage.